### PR TITLE
Fix updating user roles

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ allOpen {
 }
 
 group = "com.ampnet"
-version = "0.13.4"
+version = "0.13.5"
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 repositories {

--- a/src/main/kotlin/com/ampnet/userservice/service/impl/AdminServiceImpl.kt
+++ b/src/main/kotlin/com/ampnet/userservice/service/impl/AdminServiceImpl.kt
@@ -10,7 +10,6 @@ import com.ampnet.userservice.service.AdminService
 import com.ampnet.userservice.service.pojo.UserCount
 import mu.KLogging
 import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -47,7 +46,7 @@ class AdminServiceImpl(
      * @param coop Identifier of the coop to which the user belongs
      * @param userUuid UUID of the user
      * @param role new UserRole to assign to the user
-     * @throws InvalidRequestException for the request role UserRole.USER
+     * @throws InvalidRequestException for the request role UserRole.USER or for a missing user in coop
      * @return User with the updated role
      */
     @Transactional

--- a/src/main/kotlin/com/ampnet/userservice/service/impl/AdminServiceImpl.kt
+++ b/src/main/kotlin/com/ampnet/userservice/service/impl/AdminServiceImpl.kt
@@ -10,6 +10,7 @@ import com.ampnet.userservice.service.AdminService
 import com.ampnet.userservice.service.pojo.UserCount
 import mu.KLogging
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -38,9 +39,38 @@ class AdminServiceImpl(
     override fun findByRoles(coop: String, roles: List<UserRole>): List<User> =
         userRepository.findByCoopAndRoleIn(coop, roles.map { it })
 
+    /**
+     * Change user role works only with following logic. There can only one user for each of the following roles:
+     * UserRole.ADMIN, UserRole.PLATFORM_MANAGER, UserRole.TOKEN_ISSUER because roles are tightly coupled to permission
+     * for singing transactions on blockchain. Only one address can have ownership over smart contract.
+     *
+     * @param coop Identifier of the coop to which the user belongs
+     * @param userUuid UUID of the user
+     * @param role new UserRole to assign to the user
+     * @throws InvalidRequestException for the request role UserRole.USER
+     * @return User with the updated role
+     */
     @Transactional
     @Throws(InvalidRequestException::class)
-    override fun changeUserRole(coop: String, userUuid: UUID, role: UserRole): User {
+    override fun changeUserRole(coop: String, userUuid: UUID, role: UserRole): User =
+        when (role) {
+            UserRole.ADMIN -> {
+                findByRoles(coop, listOf(UserRole.PLATFORM_MANAGER, UserRole.TOKEN_ISSUER)).forEach {
+                    it.role = UserRole.USER
+                }
+                setUserRole(coop, userUuid, UserRole.ADMIN)
+            }
+            UserRole.TOKEN_ISSUER, UserRole.PLATFORM_MANAGER -> {
+                findByRole(coop, role, Pageable.unpaged()).forEach {
+                    it.role = UserRole.USER
+                }
+                setUserRole(coop, userUuid, role)
+            }
+            UserRole.USER ->
+                throw InvalidRequestException(ErrorCode.INT_REQUEST, "Cannot update user role to USER for coop: $coop")
+        }
+
+    private fun setUserRole(coop: String, userUuid: UUID, role: UserRole): User {
         val user = userRepository.findByCoopAndUuid(coop, userUuid).orElseThrow {
             throw InvalidRequestException(ErrorCode.USER_MISSING, "Missing user with uuid: $userUuid for coop: $coop")
         }


### PR DESCRIPTION
Fixes [AB#705](https://dev.azure.com/ampnetio/4ae90ee7-b121-4faa-8d43-d4346631309d/_workitems/edit/705)

Clean previous role owners before setting a new one that role. Fix the problem where old role owner was never downgraded to the user role.