### PR TITLE
Handle multiple user info

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ allOpen {
 }
 
 group = "com.ampnet"
-version = "0.18.0"
+version = "0.18.1"
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 repositories {

--- a/src/main/kotlin/com/ampnet/userservice/grpc/GrpcUserServer.kt
+++ b/src/main/kotlin/com/ampnet/userservice/grpc/GrpcUserServer.kt
@@ -145,7 +145,7 @@ class GrpcUserServer(
                 ?: throw ResourceNotFoundException(ErrorCode.COOP_MISSING, "Missing coop: ${request.coop} on platform")
             val users = userRepository.findAllByCoopAndUserInfoUuidIsNotNull(request.coop)
                 .associateBy { it.userInfoUuid }
-            val usersWithExtendedInfo = userInfoRepository.findAllByCoop(request.coop).map { userInfo ->
+            val usersWithExtendedInfo = userInfoRepository.findAllConnectedByCoop(request.coop).map { userInfo ->
                 users[userInfo.uuid]?.let { user -> buildUserExtendedResponse(user, userInfo) }
             }
             val response = UsersExtendedResponse.newBuilder()

--- a/src/main/kotlin/com/ampnet/userservice/persistence/repository/UserInfoRepository.kt
+++ b/src/main/kotlin/com/ampnet/userservice/persistence/repository/UserInfoRepository.kt
@@ -3,15 +3,14 @@ package com.ampnet.userservice.persistence.repository
 import com.ampnet.userservice.persistence.model.UserInfo
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
-import java.util.Optional
 import java.util.UUID
 
 interface UserInfoRepository : JpaRepository<UserInfo, UUID> {
-    fun findBySessionId(sessionId: String): Optional<UserInfo>
+    fun findBySessionIdOrderByCreatedAtDesc(sessionId: String): List<UserInfo>
 
     @Query(
         "SELECT userInfo FROM UserInfo userInfo INNER JOIN User user ON userInfo.uuid = user.userInfoUuid " +
-            "WHERE user.coop = :coop"
+            "WHERE user.coop = :coop AND userInfo.connected = true"
     )
-    fun findAllByCoop(coop: String): List<UserInfo>
+    fun findAllConnectedByCoop(coop: String): List<UserInfo>
 }

--- a/src/main/kotlin/com/ampnet/userservice/service/impl/AdminServiceImpl.kt
+++ b/src/main/kotlin/com/ampnet/userservice/service/impl/AdminServiceImpl.kt
@@ -80,7 +80,7 @@ class AdminServiceImpl(
 
     @Transactional(readOnly = true)
     override fun countUsers(coop: String): UserCount {
-        val userInfos = userInfoRepository.findAllByCoop(coop)
+        val userInfos = userInfoRepository.findAllConnectedByCoop(coop)
         val registeredUsers = userRepository.countByCoop(coop).toInt()
         val activatedUsers = userInfos.filter { it.connected }.size
         val deactivatedUsers = userInfos.filter { it.deactivated }.size

--- a/src/main/kotlin/com/ampnet/userservice/service/impl/UserServiceImpl.kt
+++ b/src/main/kotlin/com/ampnet/userservice/service/impl/UserServiceImpl.kt
@@ -65,13 +65,10 @@ class UserServiceImpl(
     @Transactional
     @Throws(ResourceNotFoundException::class)
     override fun connectUserInfo(userUuid: UUID, sessionId: String): User {
+        val userInfo = userInfoRepository.findBySessionIdOrderByCreatedAtDesc(sessionId).firstOrNull()
+            ?: throw ResourceNotFoundException(ErrorCode.REG_INCOMPLETE, "Missing UserInfo with session id: $sessionId")
         val user = getUser(userUuid)
-        if (user.userInfoUuid != null) {
-            return user
-        }
-        val userInfo = userInfoRepository.findBySessionId(sessionId).orElseThrow {
-            throw ResourceNotFoundException(ErrorCode.REG_INCOMPLETE, "Missing UserInfo with session id: $sessionId")
-        }
+        disconnectUserInfo(user)
         userInfo.connected = true
         user.userInfoUuid = userInfo.uuid
         user.firstName = userInfo.firstName
@@ -96,6 +93,17 @@ class UserServiceImpl(
         val user = getUser(userUuid)
         user.language = request.language
         return user
+    }
+
+    private fun disconnectUserInfo(user: User) {
+        user.userInfoUuid?.let {
+            userInfoRepository.findById(it).ifPresent { userInfo ->
+                userInfo.connected = false
+                userInfo.deactivated = true
+                userInfoRepository.save(userInfo)
+                logger.info { "Disconnected old user info: ${userInfo.uuid} for user: ${user.uuid}" }
+            }
+        }
     }
 
     private fun getUser(userUuid: UUID): User = find(userUuid)

--- a/src/main/kotlin/com/ampnet/userservice/service/impl/UserServiceImpl.kt
+++ b/src/main/kotlin/com/ampnet/userservice/service/impl/UserServiceImpl.kt
@@ -100,7 +100,6 @@ class UserServiceImpl(
             userInfoRepository.findById(it).ifPresent { userInfo ->
                 userInfo.connected = false
                 userInfo.deactivated = true
-                userInfoRepository.save(userInfo)
                 logger.info { "Disconnected old user info: ${userInfo.uuid} for user: ${user.uuid}" }
             }
         }

--- a/src/test/kotlin/com/ampnet/userservice/controller/IdentyumControllerTest.kt
+++ b/src/test/kotlin/com/ampnet/userservice/controller/IdentyumControllerTest.kt
@@ -134,8 +134,8 @@ class IdentyumControllerTest : ControllerTestBase() {
             ).andExpect(status().isOk)
         }
         verify("UserInfo is created") {
-            val optionalUserInfo = userInfoRepository.findBySessionId(clientSessionUuid)
-            assertThat(optionalUserInfo).isPresent
+            val userInfoList = userInfoRepository.findBySessionIdOrderByCreatedAtDesc(clientSessionUuid)
+            assertThat(userInfoList.first().connected).isTrue()
         }
     }
 

--- a/src/test/kotlin/com/ampnet/userservice/controller/VeriffControllerTest.kt
+++ b/src/test/kotlin/com/ampnet/userservice/controller/VeriffControllerTest.kt
@@ -77,9 +77,9 @@ class VeriffControllerTest : ControllerTestBase() {
                 .andExpect(MockMvcResultMatchers.status().isOk)
         }
         verify("User info is stored") {
-            val userInfo = userInfoRepository.findBySessionId("12df6045-3846-3e45-946a-14fa6136d78b")
-            assertThat(userInfo).isPresent
-            assertThat(userInfo.get().connected).isTrue()
+            val userInfoList = userInfoRepository
+                .findBySessionIdOrderByCreatedAtDesc("12df6045-3846-3e45-946a-14fa6136d78b")
+            assertThat(userInfoList.first().connected).isTrue()
         }
     }
 

--- a/src/test/kotlin/com/ampnet/userservice/grpc/GrpcUserServerTest.kt
+++ b/src/test/kotlin/com/ampnet/userservice/grpc/GrpcUserServerTest.kt
@@ -192,7 +192,7 @@ class GrpcUserServerTest : TestBase() {
                 it.userInfoUuid = userInfo.uuid
                 testContext.userInfos.add(userInfo)
             }
-            Mockito.`when`(userInfoRepository.findAllByCoop(COOP)).thenReturn(testContext.userInfos)
+            Mockito.`when`(userInfoRepository.findAllConnectedByCoop(COOP)).thenReturn(testContext.userInfos)
         }
 
         verify("Grpc service will return users") {


### PR DESCRIPTION
Enable user to handle multiple user info records. Connect the news one and disconnect the older.
Fixes [AB#802](https://dev.azure.com/ampnetio/4ae90ee7-b121-4faa-8d43-d4346631309d/_workitems/edit/802)